### PR TITLE
Host information in the headers shouldn't contain http or https

### DIFF
--- a/lib/datadog.js
+++ b/lib/datadog.js
@@ -68,7 +68,7 @@ Datadog.prototype._post = function(controller, message) {
       path: '/api/v1/' + controller + '?api_key=' + client.api_key,
       method: 'POST',
       headers: {
-         "Host": client.api_host,
+         "Host": api_host,
          "Content-Length": body.length,
          "Content-Type": "application/json"
       }


### PR DESCRIPTION
Otherwise this is causing the ssl certificate validation to fail
