### PR TITLE
Adds a Prefix Option to DataDog StatsD Metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A plugin to connect etsy's statsD to Datadog
 
 ```js
 datadogApiKey: "your_api_key" // You can get it from this page: https://app.datadoghq.com/account/settings#api
+datadogPrefix: "your_prefix"
 ```
 
 ## How to enable

--- a/lib/datadog.js
+++ b/lib/datadog.js
@@ -95,7 +95,7 @@ var flush_stats = function datadog_post_stats(ts, metrics) {
       var valuePerSecond = value / (flushInterval / 1000); // calculate 'per second' rate
 
       payload.push({
-         metric: key,
+         metric: get_prefix(key),
          points: [[ts, valuePerSecond]],
          type: 'gauge',
          host: host
@@ -107,7 +107,7 @@ var flush_stats = function datadog_post_stats(ts, metrics) {
       value = gauges[key];
 
       payload.push({
-         metric: key,
+         metric: get_prefix(key),
          points: [[ts, value]],
          type: 'gauge',
          host: host
@@ -142,35 +142,35 @@ var flush_stats = function datadog_post_stats(ts, metrics) {
          }
 
          payload.push({
-            metric: key + '.mean',
+            metric: get_prefix(key + '.mean'),
             points: [[ts, mean]],
             type: 'gauge',
             host: host
          });
 
          payload.push({
-            metric: key + '.upper',
+            metric: get_prefix(key + '.upper'),
             points: [[ts, max]],
             type: 'gauge',
             host: host
          });
 
          payload.push({
-            metric: key + '.upper_' + pctThreshold,
+            metric: get_prefix(key + '.upper_' + pctThreshold),
             points: [[ts, maxAtThreshold]],
             type: 'gauge',
             host: host
          });
 
          payload.push({
-            metric: key + '.lower',
+            metric: get_prefix(key + '.lower'),
             points: [[ts, min]],
             type: 'gauge',
             host: host
          });
 
          payload.push({
-            metric: key + '.count',
+            metric: get_prefix(key + '.count'),
             points: [[ts, count]],
             type: 'gauge',
             host: host

--- a/lib/datadog.js
+++ b/lib/datadog.js
@@ -181,6 +181,14 @@ var flush_stats = function datadog_post_stats(ts, metrics) {
    post_stats(payload);
 };
 
+var get_prefix = function datadog_get_prefix(key) {
+    if (datadogPrefix !== undefined) {
+        return [datadogPrefix, key].join('.');
+    } else {
+        return key;
+    }
+}
+
 var backend_status = function datadog_status(writeCb) {
    var stat;
 

--- a/lib/datadog.js
+++ b/lib/datadog.js
@@ -24,6 +24,7 @@ var hostname;
 var datadogApiHost;
 var datadogApiKey;
 var datadogStats = {};
+var datadogPrefix;
 
 var Datadog = function(api_key, options) {
     options = options || {};
@@ -195,6 +196,7 @@ exports.init = function datadog_init(startup_time, config, events, log) {
 
    datadogApiKey = config.datadogApiKey;
    datadogApiHost = config.datadogApiHost;
+   datadogPrefix = config.datadogPrefix;
 
    if (!datadogApiHost) {
       datadogApiHost = 'https://app.datadoghq.com';


### PR DESCRIPTION
Much like the StatsD Graphite backend has an option for `globalPrefix`, I created a prefix for the StatsD DataDog backend.