### PR TITLE
Tag Config Option

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A plugin to connect etsy's statsD to Datadog
 ```js
 datadogApiKey: "your_api_key" // You can get it from this page: https://app.datadoghq.com/account/settings#api
 datadogPrefix: "your_prefix" // Your metrics will be prefixed by this prefix
+datadogTags: ["your:tag", "another:tag"]  // Your metrics will include these tags
 ```
 
 ## How to enable

--- a/lib/datadog.js
+++ b/lib/datadog.js
@@ -11,6 +11,8 @@
  * This backend supports the following config options:
  *
  *   datadogApiKey: Your DataDog API key
+ *   datadogPrefix: A global prefix for all metrics
+ *   datadogTags: A global set of tags for all metrics
  */
 
 var net = require('net'),

--- a/lib/datadog.js
+++ b/lib/datadog.js
@@ -25,6 +25,7 @@ var datadogApiHost;
 var datadogApiKey;
 var datadogStats = {};
 var datadogPrefix;
+var datadogTags;
 
 var Datadog = function(api_key, options) {
     options = options || {};

--- a/lib/datadog.js
+++ b/lib/datadog.js
@@ -99,7 +99,8 @@ var flush_stats = function datadog_post_stats(ts, metrics) {
          metric: get_prefix(key),
          points: [[ts, valuePerSecond]],
          type: 'gauge',
-         host: host
+         host: host,
+         tags: datadogTags
       });
    }
 
@@ -111,7 +112,8 @@ var flush_stats = function datadog_post_stats(ts, metrics) {
          metric: get_prefix(key),
          points: [[ts, value]],
          type: 'gauge',
-         host: host
+         host: host,
+         tags: datadogTags
       });
    }
 
@@ -146,35 +148,40 @@ var flush_stats = function datadog_post_stats(ts, metrics) {
             metric: get_prefix(key + '.mean'),
             points: [[ts, mean]],
             type: 'gauge',
-            host: host
+            host: host,
+            tags: datadogTags
          });
 
          payload.push({
             metric: get_prefix(key + '.upper'),
             points: [[ts, max]],
             type: 'gauge',
-            host: host
+            host: host,
+            tags: datadogTags
          });
 
          payload.push({
             metric: get_prefix(key + '.upper_' + pctThreshold),
             points: [[ts, maxAtThreshold]],
             type: 'gauge',
-            host: host
+            host: host,
+            tags: datadogTags
          });
 
          payload.push({
             metric: get_prefix(key + '.lower'),
             points: [[ts, min]],
             type: 'gauge',
-            host: host
+            host: host,
+            tags: datadogTags
          });
 
          payload.push({
             metric: get_prefix(key + '.count'),
             points: [[ts, count]],
             type: 'gauge',
-            host: host
+            host: host,
+            tags: datadogTags
          });
       }
    }

--- a/lib/datadog.js
+++ b/lib/datadog.js
@@ -205,6 +205,7 @@ exports.init = function datadog_init(startup_time, config, events, log) {
    datadogApiKey = config.datadogApiKey;
    datadogApiHost = config.datadogApiHost;
    datadogPrefix = config.datadogPrefix;
+   datadogTags = config.datadogTags;
 
    if (!datadogApiHost) {
       datadogApiHost = 'https://app.datadoghq.com';

--- a/lib/datadog.js
+++ b/lib/datadog.js
@@ -218,7 +218,7 @@ exports.init = function datadog_init(startup_time, config, events, log) {
    datadogTags = config.datadogTags;
 
     if (datadogTags === undefined || datadogTags.constructor !== Array || datadogTags.length < 1) {
-        datadogTags = "";
+        datadogTags = [];
     }
 
    if (!datadogApiHost) {

--- a/lib/datadog.js
+++ b/lib/datadog.js
@@ -208,6 +208,10 @@ exports.init = function datadog_init(startup_time, config, events, log) {
    datadogPrefix = config.datadogPrefix;
    datadogTags = config.datadogTags;
 
+    if (datadogTags === undefined || datadogTags.constructor !== Array || datadogTags.length < 1) {
+        datadogTags = "";
+    }
+
    if (!datadogApiHost) {
       datadogApiHost = 'https://app.datadoghq.com';
    }


### PR DESCRIPTION
Adds a new config option `datadogTags` which takes an array of tags and appends them to all metrics being sent through the statsd-datadog-backend.