### PR TITLE
Support sets metrics

### DIFF
--- a/lib/datadog.js
+++ b/lib/datadog.js
@@ -126,7 +126,7 @@ var flush_stats = function datadog_post_stats(ts, metrics) {
 
     payload.push({
       metric: key,
-      points: [[ts, value.size()]],
+      points: [[ts, value.values().length]],
       type: 'gauge',
       host: host
     });

--- a/lib/datadog.js
+++ b/lib/datadog.js
@@ -85,6 +85,7 @@ var flush_stats = function datadog_post_stats(ts, metrics) {
    var gauges = metrics.gauges;
    var timers = metrics.timers;
    var pctThreshold = metrics.pctThreshold;
+   var sets = metrics.sets;
 
    var host = hostname || os.hostname();
    var payload = [];
@@ -118,6 +119,18 @@ var flush_stats = function datadog_post_stats(ts, metrics) {
          tags: datadogTags
       });
    }
+
+   // send sets
+   for (key in sets) {
+    value = sets[key];
+
+    payload.push({
+      metric: key,
+      points: [[ts, value.size()]],
+      type: 'gauge',
+      host: host
+    });
+  }
 
    // Compute timers and send
    for (key in timers) {


### PR DESCRIPTION
I re-merged the commit from @jtblin to support sets and updated it to work with the 0.7.2 set API using the same method (array length) that the 0.7.2 graphite backend uses. 
