### PR TITLE
Adding percentiles for mean, sum, upper at thresholds.

### DIFF
--- a/lib/datadog.js
+++ b/lib/datadog.js
@@ -84,7 +84,7 @@ var flush_stats = function datadog_post_stats(ts, metrics) {
    var counters = metrics.counters;
    var gauges = metrics.gauges;
    var timers = metrics.timers;
-   var pctThreshold = metrics.pctThreshold;
+   var pctThresholds = metrics.pctThreshold;
 
    var host = hostname || os.hostname();
    var payload = [];
@@ -127,32 +127,32 @@ var flush_stats = function datadog_post_stats(ts, metrics) {
          var min = values[0];
          var max = values[count - 1];
 
-         var mean = min;
-         var maxAtThreshold = max;
+         /* per https://github.com/etsy/statsd/blob/v0.7.2/docs/metric_types.md#timing
+            we should supply mean_$PCT, upper_$PCT, and sum_$PCT for each requested
+            percentile. */
+         var mean = {};
+         var maxAtThresholds = {};
+         var sum = {};
+         pctThresholds.forEach(function (pctThreshold) {
+           maxAtThresholds[pctThreshold] = max;
+           mean[pctThreshold] = min;
+           sum[pctThreshold] = 0;
+         });
          var i;
 
          if (count > 1) {
-            var thresholdIndex = Math.round(((100 - pctThreshold) / 100) * count);
-            var numInThreshold = count - thresholdIndex;
-            var pctValues = values.slice(0, numInThreshold);
-            maxAtThreshold = pctValues[numInThreshold - 1];
+            pctThresholds.forEach(function (pctThreshold) {
+              var thresholdIndex = Math.round(((100 - pctThreshold) / 100) * count);
+              var numInThreshold = count - thresholdIndex;
+              var pctValues = values.slice(0, numInThreshold);
+              maxAtThresholds[pctThreshold] = pctValues[numInThreshold - 1];
 
-            // average the remaining timings
-            var sum = 0;
-            for (i = 0; i < numInThreshold; i++) {
-               sum += pctValues[i];
-            }
-
-            mean = sum / numInThreshold;
+              for (i=0; i < numInThreshold; i++) {
+                sum[pctThreshold] += pctValues[i];
+              }
+              mean[pctThreshold] = sum[pctThreshold] / numInThreshold;
+            });
          }
-
-         payload.push({
-            metric: get_prefix(key + '.mean'),
-            points: [[ts, mean]],
-            type: 'gauge',
-            host: host,
-            tags: datadogTags
-         });
 
          payload.push({
             metric: get_prefix(key + '.upper'),
@@ -162,12 +162,30 @@ var flush_stats = function datadog_post_stats(ts, metrics) {
             tags: datadogTags
          });
 
-         payload.push({
-            metric: get_prefix(key + '.upper_' + pctThreshold),
-            points: [[ts, maxAtThreshold]],
-            type: 'gauge',
-            host: host,
-            tags: datadogTags
+         pctThresholds.forEach(function (pctThreshold) {
+           payload.push({
+              metric: get_prefix(key + '.mean_' + pctThreshold),
+              points: [[ts, mean[pctThreshold]]],
+              type: 'gauge',
+              host: host,
+              tags: datadogTags
+           });
+
+           payload.push({
+              metric: get_prefix(key + '.upper_' + pctThreshold),
+              points: [[ts, maxAtThresholds[pctThreshold]]],
+              type: 'gauge',
+              host: host,
+              tags: datadogTags
+           });
+
+           payload.push({
+              metric: get_prefix(key + '.sum_' + pctThreshold),
+              points: [[ts, sum[pctThreshold]]],
+              type: 'gauge',
+              host: host,
+              tags: datadogTags
+           });
          });
 
          payload.push({

--- a/lib/datadog.js
+++ b/lib/datadog.js
@@ -82,9 +82,11 @@ var post_stats = function datadog_post_stats(payload) {
 
 var flush_stats = function datadog_post_stats(ts, metrics) {
    var counters = metrics.counters;
+   var counter_rates = metrics.counter_rates;
    var gauges = metrics.gauges;
-   var timers = metrics.timers;
+   var timers = metrics.timer_data;
    var pctThresholds = metrics.pctThreshold;
+   var statsd_metrics = metrics.statsd_metrics;
 
    var host = hostname || os.hostname();
    var payload = [];
@@ -92,15 +94,34 @@ var flush_stats = function datadog_post_stats(ts, metrics) {
 
    var key;
 
+   for (key in statsd_metrics) {
+     payload.push({
+        metric: get_prefix(key),
+        points: [[ts, statsd_metrics[key]]],
+        type: 'gauge',
+        host: host,
+        tags: datadogTags
+     });
+   }
+
    // Send counters
    for (key in counters) {
       value = counters[key];
-      var valuePerSecond = value / (flushInterval / 1000); // calculate 'per second' rate
+      // Fetch the pre-caculated rate
+      var valuePerSecond = counter_rates[key];
+
+      payload.push({
+         metric: get_prefix(key) + ".per_second",
+         points: [[ts, valuePerSecond]],
+         type: 'gauge',
+         host: host,
+         tags: datadogTags
+      });
 
       payload.push({
          metric: get_prefix(key),
-         points: [[ts, valuePerSecond]],
-         type: 'gauge',
+         points: [[ts, value]],
+         type: 'counter',
          host: host,
          tags: datadogTags
       });
@@ -119,91 +140,30 @@ var flush_stats = function datadog_post_stats(ts, metrics) {
       });
    }
 
-   // Compute timers and send
+   // Send timer data
    for (key in timers) {
-      if (timers[key].length > 0) {
-         var values = timers[key].sort(function (a,b) { return a-b; });
-         var count = values.length;
-         var min = values[0];
-         var max = values[count - 1];
+     for (timer_data_key in timers[key]) {
 
-         /* per https://github.com/etsy/statsd/blob/v0.7.2/docs/metric_types.md#timing
-            we should supply mean_$PCT, upper_$PCT, and sum_$PCT for each requested
-            percentile. */
-         var mean = {};
-         var maxAtThresholds = {};
-         var sum = {};
-         pctThresholds.forEach(function (pctThreshold) {
-           maxAtThresholds[pctThreshold] = max;
-           mean[pctThreshold] = min;
-           sum[pctThreshold] = 0;
-         });
-         var i;
-
-         if (count > 1) {
-            pctThresholds.forEach(function (pctThreshold) {
-              var thresholdIndex = Math.round(((100 - pctThreshold) / 100) * count);
-              var numInThreshold = count - thresholdIndex;
-              var pctValues = values.slice(0, numInThreshold);
-              maxAtThresholds[pctThreshold] = pctValues[numInThreshold - 1];
-
-              for (i=0; i < numInThreshold; i++) {
-                sum[pctThreshold] += pctValues[i];
-              }
-              mean[pctThreshold] = sum[pctThreshold] / numInThreshold;
-            });
+       if (typeof(timers[key][timer_data_key]) === 'number') {
+        payload.push({
+           metric: get_prefix(key + "." + timer_data_key),
+           points: [[ts, timers[key][timer_data_key]]],
+           type: 'gauge',
+           host: host,
+           tags: datadogTags
+        });
+       } else {
+         for (var timer_data_sub_key in timers[key][timer_data_key]) {
+           payload.push({
+              metric: get_prefix(key + "." + timer_data_key + "." + timer_data_sub_key),
+              points: [[ts, timers[key][timer_data_key][timer_data_sub_key]]],
+              type: 'gauge',
+              host: host,
+              tags: datadogTags
+           });
          }
-
-         payload.push({
-            metric: get_prefix(key + '.upper'),
-            points: [[ts, max]],
-            type: 'gauge',
-            host: host,
-            tags: datadogTags
-         });
-
-         pctThresholds.forEach(function (pctThreshold) {
-           payload.push({
-              metric: get_prefix(key + '.mean_' + pctThreshold),
-              points: [[ts, mean[pctThreshold]]],
-              type: 'gauge',
-              host: host,
-              tags: datadogTags
-           });
-
-           payload.push({
-              metric: get_prefix(key + '.upper_' + pctThreshold),
-              points: [[ts, maxAtThresholds[pctThreshold]]],
-              type: 'gauge',
-              host: host,
-              tags: datadogTags
-           });
-
-           payload.push({
-              metric: get_prefix(key + '.sum_' + pctThreshold),
-              points: [[ts, sum[pctThreshold]]],
-              type: 'gauge',
-              host: host,
-              tags: datadogTags
-           });
-         });
-
-         payload.push({
-            metric: get_prefix(key + '.lower'),
-            points: [[ts, min]],
-            type: 'gauge',
-            host: host,
-            tags: datadogTags
-         });
-
-         payload.push({
-            metric: get_prefix(key + '.count'),
-            points: [[ts, count]],
-            type: 'gauge',
-            host: host,
-            tags: datadogTags
-         });
-      }
+       }
+     }
    }
 
    post_stats(payload);


### PR DESCRIPTION
# What’s this PR do?

This PR changes the behavior of the datadog statsd backend to handle statsd’s `pctThreshold` parameter as an Array rather than a number, and splits out `mean_$PCT`, `sum_$PCT`, and `upper_$PCT` for each of the requested percentile thresholds.
# Motivation

Currently the datadog statsd backend tries to parse `pctThreshold` as a number, but statsd uses an Array of numbers instead. This causes the datadog backend to end up with confused metric names (e.g., `metric.upper_90_95_99` if `pctThreshold = [90, 95, 99]`) and `NaN` values for `mean` and `upper_...`.
# Notes

To match [the percentile stats mentioned in the docs for statsd 0.7.2](https://github.com/etsy/statsd/blob/v0.7.2/docs/metric_types.md#timing), I’ve also added `sum_$PCT` to represent the sum of all the counted samples in the percentile that we’re concerned with.

If `metric.mean` was already working for some installs, this behavioral change will break it; however, as far as I can tell, statsd has been using an Array of values for `pctThreshold` as far back as v0.2.0.
