### PR TITLE
Add datadog API host to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,19 +6,21 @@ A plugin to connect etsy's statsD to Datadog
 
     $ cd /path/to/statsd-dir
     $ npm install statsd-datadog-backend
-    
+
 ## Configuration
 
 ```js
-datadogApiKey: "your_api_key" // You can get it from this page: https://app.datadoghq.com/account/settings#api
-datadogPrefix: "your_prefix" // Your metrics will be prefixed by this prefix
-datadogTags: ["your:tag", "another:tag"]  // Your metrics will include these tags
+datadogApiKey: "your_api_key"; // You can get it from this page: https://app.datadoghq.com/account/settings#api
+datadogApiHost: "https://app.datadoghq.com" // Could also be "https://app.datadoghq.eu" for Europe.
+datadogPrefix: "your_prefix"; // Your metrics will be prefixed by this prefix
+datadogApiHost: "https://app.datadoghq.com";
+datadogTags: ["your:tag", "another:tag"]; // Your metrics will include these tags
 ```
 
 ## How to enable
+
 Add statsd-datadog-backend to your list of statsd backends:
 
 ```js
-backends: ["statsd-datadog-backend"]
+backends: ["statsd-datadog-backend"];
 ```
-

--- a/lib/datadog.js
+++ b/lib/datadog.js
@@ -11,6 +11,7 @@
  * This backend supports the following config options:
  *
  *   datadogApiKey: Your DataDog API key
+ *   datadogApiHost: Your DataDog API host
  *   datadogPrefix: A global prefix for all metrics
  *   datadogTags: A global set of tags for all metrics
  */


### PR DESCRIPTION
Took me a while to figure out why I was not seeing any metrics and then I looked at the source code and I saw I could configure the host. So to make sure that other people will not spend that much time on it, I added this to the documentation :).
