### PR TITLE
Adds codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# See https://help.github.com/articles/about-codeowners/ for syntax
+# Rules are matched bottom-to-top, so one team can own subdirectories
+# and another team can own the rest of the directory.
+
+
+# Documentation
+*                     @DataDog/agent-metrics-logs
+*.md                  @DataDog/documentation


### PR DESCRIPTION
Agent-metrics-logs owns this repo, except for any markdown docs. The usual template.